### PR TITLE
Modify metafields section

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -106,6 +106,7 @@
       "product_variants": "Product variants",
       "actual_item_image": "Actual item pictured",
       "stock_item_image": "Stock photo",
+      "battery_info": " Compatible battery type(s) for the ",
       "taxable_html": "Your countries <a class=\"link\" href=\"\/pages\/vat\">VAT<\/a>. incl. (EU only).",
       "not_taxable_html": "Price as shown. Used item, no deductible <a class=\"link\" href=\"\/pages\/vat\">VAT<\/a>.",
       "media": {

--- a/sections/main-product-description.liquid
+++ b/sections/main-product-description.liquid
@@ -59,16 +59,16 @@
           <b>{{ host_product.title }}</b>
           <div>{{ host_product.description }}</div>
           {% unless host_product.description contains "Battery" %}
-          <div class="metafields-container">
             {% if product.metafields.kameratori.batteries and product.metafields.kameratori.batteries.value.size > 0 %}
-            Battery:
-            {% for battery in product.metafields.kameratori.batteries.value %}
-              <b> {{battery}}</b> (Not included)
-              {% if forloop.last != true %}, {% else %}<br />{% endif %}
-            {% endfor %}
+            <div>
+              {{ "products.product.battery_info" | t }}{{product.title | remove_first: "-" }}:
+                  {% for battery in product.metafields.kameratori.batteries.value %}
+                  <b> {{battery}}</b>
+                  {% if forloop.last != true %}, {% else %}<br />{% endif %}
+                {% endfor %}
+            </div>
           {% endif %}
           {% endunless %}
-          </div>
           {% assign previous_content_section_shown = true %}
         {% endif %}
       {%- when 'main_kit_stock' -%}

--- a/sections/main-product-description.liquid
+++ b/sections/main-product-description.liquid
@@ -58,6 +58,17 @@
           {% endif %}
           <b>{{ host_product.title }}</b>
           <div>{{ host_product.description }}</div>
+          {% unless host_product.description contains "Battery" %}
+          <div class="metafields-container">
+            {% if product.metafields.kameratori.batteries and product.metafields.kameratori.batteries.value.size > 0 %}
+            Battery:
+            {% for battery in product.metafields.kameratori.batteries.value %}
+              <b> {{battery}}</b> (Not included)
+              {% if forloop.last != true %}, {% else %}<br />{% endif %}
+            {% endfor %}
+          {% endif %}
+          {% endunless %}
+          </div>
           {% assign previous_content_section_shown = true %}
         {% endif %}
       {%- when 'main_kit_stock' -%}
@@ -99,14 +110,6 @@
                 {% if forloop.last != true %}, {% endif %}
               {% endfor %}
               <br />
-            {% endif %}
-
-            {% if product.metafields.kameratori.batteries and product.metafields.kameratori.batteries.value.size > 0 %}
-              Battery:
-              {% for battery in product.metafields.kameratori.batteries.value %}
-                <b> {{battery}}</b>
-                {% if forloop.last != true %}, {% else %}<br />{% endif %}
-              {% endfor %}
             {% endif %}
 
             {% if product.metafields.kameratori.shutter_count and product.metafields.kameratori.shutter_count != "" %}


### PR DESCRIPTION
**Why are these changes introduced?**
Battery info confused customers, cause they thought the mentioned battery type would be included in the package.
Battery info is now moved below the database item description and it has sentence added to it which should info the customer about the battery type and not confuse them to think that it is included in the package. If item desciption mentions batteries (some digital bodies have) then no battery info will be rendered.
Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
