### PR TITLE
Add flair badges to be used with boost

### DIFF
--- a/assets/boost-pfs-filter.js
+++ b/assets/boost-pfs-filter.js
@@ -95,6 +95,7 @@ var boostPFSFilterConfig = {
 		if (productSystem) {
 			productSystem = productSystem.slice(7, 57);
 		}
+		
 
 		// Add main attribute (Always put at the end of this function)
 		itemHtml = itemHtml.replace(/{{itemId}}/g, data.id);
@@ -102,6 +103,7 @@ var boostPFSFilterConfig = {
 		itemHtml = itemHtml.replace(/{{itemHandle}}/g, data.handle);
 		itemHtml = itemHtml.replace(/{{itemVendorLabel}}/g, productSystem || data.vendor);
 		itemHtml = itemHtml.replace(/{{itemUrl}}/g, Utils.buildProductItemUrl(data));
+		itemHtml = itemHtml.replace(/{{itemFlairHtml}}/g, '<div data-flair-product-badge data-product-id="' + data.id.toString() + '"></div>');
 		return itemHtml;
 	};
 
@@ -398,7 +400,8 @@ var boostPFSFilterConfig = {
   // Add additional feature for product list, used commonly in customizing product list
 	ProductList.prototype.afterRender = function(data) {
 		if (!data) data = this.data;
-	}
+		if (typeof FlairApp !== 'undefined' && FlairApp) { FlairApp.refreshProductBadges(); }
+	};
 
 	// Build Additional Elements
 	Filter.prototype.afterRender = function(data, eventType) {

--- a/snippets/boost-pfs-filter-html.liquid
+++ b/snippets/boost-pfs-filter-html.liquid
@@ -17,6 +17,7 @@
       <div class="card-information">
         <div class="card-information__wrapper">
           [[itemVendor]]
+          [[itemFlairHtml]]
           <span class="card-information__text h5">[[itemTitle]]</span>
           {% if section.settings.show_rating %}
           [[itemReviews]]


### PR DESCRIPTION
**Why are these changes introduced?**
These changes were introduced to integrate flair app with the boost search we are using. Integration enables us to use custom badges on products.

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
