### PR TITLE
Fix showing empty collections

### DIFF
--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -16,6 +16,7 @@
     assign more_in_collection = true
   endif
 -%}
+{% unless section.settings.collection.all_products_count == nil %}
 <div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
   <div class="title-wrapper-with-link{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
     <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>
@@ -73,6 +74,7 @@
     </div>
   {%- endif -%}
 </div>
+{% endunless %}
 
 {% schema %}
 {


### PR DESCRIPTION
**Why are these changes introduced?**
Changes were introduced because sometimes using "Featured Collections"-setting ended up showing empty collections. Now if featured collection is Nil it should not be rendered.

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
