### PR TITLE
Quality control section product

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -157,6 +157,19 @@
   --color-icon: rgb(var(--color-base-outline-button-labels));
 }
 
+/* quality control color-variables */
+
+.quality-control__container--passed, .passed > .quality-control {
+  --color-passed-bg: #EEF3FB;
+  --color-passed-border: #214E9D;
+}
+
+.quality-control__container--not-passed, .not-passed > .quality-control {
+  --color-not-passed-bg: #FEF2EB;
+  --color-not-passed-border: #F88545;
+}
+ 
+
 /* base */
 
 .no-js:not(html) {

--- a/assets/section-main-product.css
+++ b/assets/section-main-product.css
@@ -77,14 +77,14 @@
 
 @media screen and (min-width: 990px) {
   .product:not(.product--no-media):not(.featured-product) .product__media-wrapper {
-    max-width: 64%;
-    width: calc(64% - 1rem / 2);
+    max-width: 60%;
+    width: calc(60% - 1rem / 2);
   }
 
   .product:not(.product--no-media):not(.featured-product) .product__info-wrapper {
     padding-left: 4rem;
-    max-width: 36%;
-    width: calc(36% - 1rem / 2);
+    max-width: 40%;
+    width: calc(40% - 1rem / 2);
   }
 }
 

--- a/assets/section-quality-control.css
+++ b/assets/section-quality-control.css
@@ -1,4 +1,116 @@
-.qc__info {
+/*styling for quality control section used on product pages*/
+
+.quality-control {
+    margin-top: 1rem;
+    margin-bottom: -1.25rem;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding:1rem 1rem;
+    gap: 1.5rem;
+    position: relative;
+    }
+
+.passed > .quality-control {
+    /*toimii siis näin jos käyttää variablea, variablejen lisäykset base.css:äään. Mieti miten elementit kannattaa nimetä.
+    background-color: var(--main-qc-color);
+    */
+    background-color: var(--color-passed-bg);
+    border: 0.125rem solid var(--color-passed-border);
+    border-radius: 0.375rem;
+}
+
+.not-passed > .quality-control {
+    background: var(--color-not-passed-bg);
+    border: 0.125rem solid var(--color-not-passed-border);
+    border-radius: 0.375rem;
+}
+
+
+
+.quality-control > .accordion {
+    margin-top: 0;
+    margin-bottom: 0;
+    border-top: 0;
+    border-bottom: 0;
+  }
+
+.quality-control > .accordion summary {
+    display: flex;
+    position: unset;
+    line-height: unset;
+    padding: 0 0;
+  }
+
+.quality-control__title-container-badge {
+    display: flex;
+    align-items: center;
+    column-gap: 0.9rem;
+}
+
+.quality-control__title-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    word-break: break-word;
+    order: 0;
+    align-self: stretch;
+    column-gap: 0.9rem;
+    color: #3B4B5B;
+    order: 0;
+    flex-grow: 1
+ }
+
+ .quality-control__title {
+    display: flex;
+    align-items: center;
+    column-gap: 0.9rem;
+    font: normal 600 1.4rem/1.7rem Inter ;
+ }
+
+
+ .quality-control__title-container .icon-caret {
+    position: relative;
+    margin-left: 1.5rem;
+    margin-right: -1.5rem;
+}
+
+.accordion details[open] > summary .icon-caret {
+    transform: rotate(180deg);
+  }
+
+.quality-control__link{
+    text-align: center;
+    width: 100%;
+    height: 0.813rem;
+    font: normal 400 1.4rem/1.45rem Inter;
+    text-align: center;
+    text-decoration-line: underline;
+    flex: none;
+    order: 1;
+    flex-grow: 0;
+    padding-bottom: 1rem;
+    margin-bottom: 1.5rem;
+}
+.quality-control__link > a:link {
+    color: rgba(var(--color-link), var(--alpha-link));;
+  }
+
+.quality-control__link > a:visited {
+      color: rgb(var(--color-link));
+      text-decoration: underline;
+      text-decoration-thickness: 2rem;
+    }
+
+.quality-control__linki > a:hover {
+    color: rgb(var(--color-link));
+ } 
+
+/*styling for quality control info-sections (to be used on pages)*/
+.quality-control__info {
     display: flex;
     flex-direction: column;
     justify-content: right;
@@ -9,7 +121,7 @@
     padding: 0 1.5rem;
 }
 
-.qc__badge {
+.quality-control__badge {
     display: flex;
     flex-direction: row;
     justify-content: start;
@@ -21,7 +133,7 @@
     
 }
 
-.qc__wrapper {
+.quality-control__wrapper {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -29,22 +141,22 @@
     max-width: 90%;
 }
 
-.qc__container--passed {
+.quality-control__container--passed {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 0.75rem 1rem;
     gap: 1rem;
     position: relative;
     height: auto;
-    background: #EEF3FB;
-    border: 0.125rem solid #214E9D;
-    border-radius: 0.375rem;
-    background: #EEF3FB;
     margin: auto;
+    border: 0.125rem solid var(--color-passed-border);
+    border-radius: 0.375rem;
+    background: var(--color-passed-bg);
+    padding: 0.75rem 1rem;
+  
 }
 
-.qc__container--not-passed {
+.quality-control__container--not-passed {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -53,13 +165,13 @@
     position: relative;
     height: auto;
     width: auto;
-    border: 0.125rem solid #F88545;
+    border: 0.125rem solid var(--color-not-passed-border);
     border-radius: 0.375rem;
-    background: #FEF2EB;
+    background: var(--color-not-passed-bg);
     margin: auto;
 }
 
-.qc__container--reconditioned {
+.quality-control__container--reconditioned {
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -74,44 +186,44 @@
     margin: auto;
 }
 
+/*description used in both sections*/
 
-.qc__text {
+.quality-control__description {
     width: auto;
     height: auto;
-    font-family: 'Inter';
-    font-style: normal;
-    font-weight: 500;
+    font: normal 500 1.4rem/1.6rem;
     color: #49586F;
-
-    /* Inside auto layout */
     flex: none;
     order: 0;
     flex-grow: 0;
 }
 
-.qc__rtf {
-    display: flex;
-    flex-direction: row;
-    justify-content: start;
+@media screen and (max-width: 370px) {
+    
+.quality_control__title_container {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
 }
-
+}
 
 @media screen and (min-width: 450px) {
-    .qc__wrapper {
-        max-width: 60%;
-    }
- }
+.quality-control__wrapper {
+    max-width: 60%;
+}
+}
 
 @media screen and (min-width: 750px) {
-    .qc__info {
-        padding: 0 9rem;
-    }
- }
+.quality-control__info {
+    padding: 0 9rem;
+}
+}
 
 @media screen and (min-width: 990px) {
-    .qc__info {
-        max-width: 72.6rem;
-        padding: 0;
-    }
+.quality-control__info {
+    max-width: 72.6rem;
+    padding: 0;
 }
-    
+}
+
+

--- a/assets/section-quality-control.css
+++ b/assets/section-quality-control.css
@@ -12,9 +12,7 @@
     }
 
 .passed > .quality-control {
-    /*toimii siis näin jos käyttää variablea, variablejen lisäykset base.css:äään. Mieti miten elementit kannattaa nimetä.
-    background-color: var(--main-qc-color);
-    */
+ 
     background-color: var(--color-passed-bg);
     border: 0.125rem solid var(--color-passed-border);
     border-radius: 0.375rem;

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -202,6 +202,12 @@
         "other": "{{ count }} items"
       }
     },
+    "quality_control_tab": {
+      "heading": "Quality Control Rating",
+      "link": {
+        "text": "Read more about our ratings"
+      }
+    },
     "cart": {
       "title": "Your cart",
       "caption": "Cart items",

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1456,6 +1456,22 @@
             }
           }
         },
+        "quality_control_tab": {
+          "name": "Quality Control Tab",
+          "settings": {
+            "heading": {
+              "info": "Include a heading that explains the content.",
+              "label": "Heading"
+            },
+            "content_passed": {
+              "label": "Tab content for passed",
+              "default": "Testi"
+            },
+            "content_not_passed": {
+              "label": "Tab content for not passed"
+            }
+          }
+        },
         "collapsible_tab": {
           "name": "Collapsible tab",
           "settings": {

--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -1464,8 +1464,7 @@
               "label": "Heading"
             },
             "content_passed": {
-              "label": "Tab content for passed",
-              "default": "Testi"
+              "label": "Tab content for passed"
             },
             "content_not_passed": {
               "label": "Tab content for not passed"

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -199,6 +199,12 @@
         "other": "{{ count }} tuotetta"
       }
     },
+    "quality_control_tab": {
+      "heading": "Kuntoarvio",
+      "link": {
+        "text": "Lue lisää kuntoarvioinnista"
+      }
+    },
     "cart": {
       "title": "Ostoskorisi",
       "caption": "Ostoskorin tuotteet",

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -5,6 +5,7 @@
 {{ 'component-rte.css' | asset_url | stylesheet_tag }}
 {{ 'component-slider.css' | asset_url | stylesheet_tag }}
 {{ 'component-rating.css' | asset_url | stylesheet_tag }}
+{{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
 
 <link rel="stylesheet" href="{{ 'component-deferred-media.css' | asset_url }}" media="print" onload="this.media='all'">
 
@@ -180,6 +181,54 @@
                 </div>
               </details>
             </div>
+            {%- when 'quality_control_tab' -%}
+            {% if product.metafields.kameratori.quality_control.value != 'Error' and product.metafields.kameratori.quality_control.value != blank %}
+            {% assign quality_control_value = product.metafields.kameratori.quality_control.value %}
+                <div class={{quality_control_value|downcase|replace: " ", "-"}}>
+                <div class="quality-control">
+                <div class="accordion" {{ block.shopify_attributes }}>
+                    {%- if quality_control_value=="Passed" -%}
+                    <details>
+                    {%- elsif quality_control_value=="Not Passed" -%}
+                    <details open>
+                    {%- endif -%}  
+                    <summary>
+                        <div class="quality-control__title-container">
+                          <div class="quality-control__title">
+                            {% comment %} quality control value defines what we show next, first for Passed {% endcomment %}
+                            {% if quality_control_value =="Passed" %}
+                              {% render 'icon-passed-ellips' %}
+                              {{"sections.quality_control_tab.heading" | t }}
+                            </div>
+                            <div class="quality-control__title-container-badge">
+                              {%- render 'qc-badge-passed' -%}
+                              {% comment %} and here for the Not Passed{% endcomment %} 
+                            {% elsif quality_control_value =="Not Passed" %}
+                              {% render 'icon-not-passed-ellips' %}
+                              {{"sections.quality_control_tab.heading" | t }}
+                            </div>
+                            <div class="quality-control__title-container-badge">
+                            {% render 'qc-badge-not-passed' %}
+                          {% endif %}
+                            {% render 'icon-caret' %}
+                            </div>
+                        </div>
+                      </summary>
+                      <div class="quality-control__description">
+                        {% if quality_control_value == "Passed" %}
+                        {{ block.settings.content_passed}}
+                        {% elsif quality_control_value == "Not Passed" %}
+                        {{ block.settings.content_not_passed }}
+                        {% endif %}
+                      </div>
+                      <div class="quality-control__link">
+                        <a href="/pages/product-quality-control-item-condition-rating" target="_blank" rel="noopener noreferrer">{{"sections.quality_control_tab.link.text" | t }}</a> 
+                      </div>
+                    </details>
+                  </div>
+                  </div>
+                  </div>
+              {% endif %}
           {%- when 'quantity_selector' -%}
             <div class="product-form__input product-form__quantity" {{ block.shopify_attributes }}>
               <label class="form__label" for="Quantity-{{ section.id }}">
@@ -896,6 +945,30 @@
           "id": "custom_liquid",
           "label": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid.label",
           "info": "t:sections.main-product.blocks.custom_liquid.settings.custom_liquid.info"
+        }
+      ]
+    },
+    {
+      "type": "quality_control_tab",
+      "name": "t:sections.main-product.blocks.quality_control_tab.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "quality_control",
+          "info": "t:sections.main-product.blocks.quality_control_tab.settings.heading.info",
+          "label": "t:sections.main-product.blocks.quality_control_tab.settings.heading.label"
+        },
+        {
+          "type": "richtext",
+          "id": "content_passed",
+          "label": "t:sections.main-product.blocks.quality_control_tab.settings.content_passed.label",
+          "default": "<p>Tested, inspected, cleaned and working with no significant flaws. These items can be considered “ready to use” for their intended purpose. Minor flaws are possible and are noted in the product description.</p>"
+        },
+        {
+          "type": "richtext",
+          "id": "content_not_passed",
+          "label": "t:sections.main-product.blocks.quality_control_tab.settings.content_not_passed.label",
+          "default": "<p>Untested or: tested, inspected, and found to have significant flaws that affect or prevent normal use. These items should be considered broken. Repair may or may not be possible.</p>"
         }
       ]
     },

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -185,61 +185,61 @@
             {% comment %} Remember to add != 'NEW/EXTENCT' when decided which tag will be used {% endcomment %}
             {% comment %} if product.metafields.kameratori.quality_control.value != 'Error-QC' and product.metafields.kameratori.quality_control.value != blank {% endcomment %}
             {%- for t in product.tags -%}
-                {% assign tag = t %}
-                  {% if tag contains 'QC-' and tag != 'QC-New' %}
+                {%- assign tag = t -%}
+                  {%- if tag contains 'QC-' and tag != 'QC-New' -%}
                     {%- assign quality_control_value = tag | remove_first: "QC-"-%}
                         <div class={{quality_control_value | downcase|replace: " ", "-"}}>
-                        <div class="quality-control">
-                        <div class="accordion" {{ block.shopify_attributes }}>
-                            {%- if quality_control_value=="Passed" -%}
-                            <details>
-                            {%- elsif quality_control_value=="Not Passed" -%}
-                            <details open>
-                            {%- endif -%}  
-                            <summary>
-                                <div class="quality-control__title-container">
-                                  <div class="quality-control__title">
-                                    {% comment %} quality control value defines what we show next, first for Passed {% endcomment %}
-                                    {% if quality_control_value =="Passed" %}
-                                      {% render 'icon-passed-ellips' %}
-                                      {{"sections.quality_control_tab.heading" | t }}
+                          <div class="quality-control">
+                            <div class="accordion" {{ block.shopify_attributes }}>
+                                {%- if quality_control_value=="Passed" -%}
+                                <details>
+                                {%- elsif quality_control_value=="Not Passed" -%}
+                                <details open>
+                                {%- endif -%}  
+                                  <summary>
+                                      <div class="quality-control__title-container">
+                                        <div class="quality-control__title">
+                                          {% comment %} quality control value defines what we show next, first for Passed {% endcomment %}
+                                          {%- if quality_control_value =="Passed" -%}
+                                            {% render 'icon-passed-ellips' %}
+                                            {{"sections.quality_control_tab.heading" | t }}
+                                          </div>
+                                          <div class="quality-control__title-container-badge">
+                                            {%- render 'qc-badge-passed' -%}
+                                            {% comment %} and here for the Not Passed{% endcomment %} 
+                                          {%- elsif quality_control_value =="Not Passed" -%}
+                                            {%- render 'icon-not-passed-ellips' -%}
+                                            {{"sections.quality_control_tab.heading" | t }}
+                                          </div>
+                                          <div class="quality-control__title-container-badge">
+                                          {%- render 'qc-badge-not-passed' -%}
+                                          {% endif %}
+                                          {%- render 'icon-caret' -%}
+                                          </div>
+                                      </div>
+                                    </summary>
+                                    <div class="quality-control__description">
+                                      {%- if quality_control_value == "Passed" -%}
+                                      {% comment %} content from the block-settings if want to use instead of metaobjects
+                                      {{ block.settings.content_passed}}
+                                      {% endcomment %}
+                                      <p>{{ shop.metaobjects.quality_control.passed.description_medium }}</p>
+                                      {%- elsif quality_control_value == "Not Passed" -%}
+                                      {% comment %} content from the block-settings if want to use instead of metaobjects
+                                      {{ block.settings.content_not_passed }}
+                                      {% endcomment %}
+                                      <p>{{ shop.metaobjects.quality_control.not-passed.description_medium}}</p>
+                                      {%- endif -%}
                                     </div>
-                                    <div class="quality-control__title-container-badge">
-                                      {%- render 'qc-badge-passed' -%}
-                                      {% comment %} and here for the Not Passed{% endcomment %} 
-                                    {% elsif quality_control_value =="Not Passed" %}
-                                      {% render 'icon-not-passed-ellips' %}
-                                      {{"sections.quality_control_tab.heading" | t }}
-                                    </div>
-                                    <div class="quality-control__title-container-badge">
-                                    {% render 'qc-badge-not-passed' %}
-                                  {% endif %}
-                                    {% render 'icon-caret' %}
-                                    </div>
-                                </div>
-                              </summary>
-                              <div class="quality-control__description">
-                                {% if quality_control_value == "Passed" %}
-                                {% comment %} content from the block-settings if want to use instead of metaobjects
-                                {{ block.settings.content_passed}}
-                                {% endcomment %}
-                                <p>{{ shop.metaobjects.quality_control.passed.description_medium }}</p>
-                                {% elsif quality_control_value == "Not Passed" %}
-                                {% comment %} content from the block-settings if want to use instead of metaobjects
-                                {{ block.settings.content_not_passed }}
-                                {% endcomment %}
-                                <p>{{ shop.metaobjects.quality_control.not-passed.description_medium}}</p>
-                                {% endif %}
+                                      <div class="quality-control__link">
+                                        <a href="/pages/product-quality-control-item-condition-rating" target="_blank" rel="noopener noreferrer">{{"sections.quality_control_tab.link.text" | t }}</a> 
+                                      </div>
+                                </details>
                               </div>
-                              <div class="quality-control__link">
-                                <a href="/pages/product-quality-control-item-condition-rating" target="_blank" rel="noopener noreferrer">{{"sections.quality_control_tab.link.text" | t }}</a> 
-                              </div>
-                            </details>
+                            </div>
                           </div>
-                          </div>
-                          </div>
-                {% endif %}
-              {% endfor %}
+                {%- endif -%}
+              {%- endfor -%}
           {%- when 'quantity_selector' -%}
             <div class="product-form__input product-form__quantity" {{ block.shopify_attributes }}>
               <label class="form__label" for="Quantity-{{ section.id }}">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -182,7 +182,7 @@
               </details>
             </div>
             {%- when 'quality_control_tab' -%}
-            {% if product.metafields.kameratori.quality_control.value != 'Error' and product.metafields.kameratori.quality_control.value != blank %}
+            {% if product.metafields.kameratori.quality_control.value != 'Error-QC' and product.metafields.kameratori.quality_control.value != blank %}
             {% assign quality_control_value = product.metafields.kameratori.quality_control.value %}
                 <div class={{quality_control_value|downcase|replace: " ", "-"}}>
                 <div class="quality-control">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -223,12 +223,12 @@
                                       {% comment %} content from the block-settings if want to use instead of metaobjects
                                       {{ block.settings.content_passed}}
                                       {% endcomment %}
-                                      <p>{{ shop.metaobjects.quality_control.passed.description_medium }}</p>
+                                      <p>{{ shop.metaobjects.quality_control.passed.description_medium | t}}</p>
                                       {%- elsif quality_control_value == "Not Passed" -%}
                                       {% comment %} content from the block-settings if want to use instead of metaobjects
                                       {{ block.settings.content_not_passed }}
                                       {% endcomment %}
-                                      <p>{{ shop.metaobjects.quality_control.not-passed.description_medium}}</p>
+                                      <p>{{ shop.metaobjects.quality_control.not-passed.description_medium | t}}</p>
                                       {%- endif -%}
                                     </div>
                                       <div class="quality-control__link">

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -182,53 +182,64 @@
               </details>
             </div>
             {%- when 'quality_control_tab' -%}
-            {% if product.metafields.kameratori.quality_control.value != 'Error-QC' and product.metafields.kameratori.quality_control.value != blank %}
-            {% assign quality_control_value = product.metafields.kameratori.quality_control.value %}
-                <div class={{quality_control_value|downcase|replace: " ", "-"}}>
-                <div class="quality-control">
-                <div class="accordion" {{ block.shopify_attributes }}>
-                    {%- if quality_control_value=="Passed" -%}
-                    <details>
-                    {%- elsif quality_control_value=="Not Passed" -%}
-                    <details open>
-                    {%- endif -%}  
-                    <summary>
-                        <div class="quality-control__title-container">
-                          <div class="quality-control__title">
-                            {% comment %} quality control value defines what we show next, first for Passed {% endcomment %}
-                            {% if quality_control_value =="Passed" %}
-                              {% render 'icon-passed-ellips' %}
-                              {{"sections.quality_control_tab.heading" | t }}
-                            </div>
-                            <div class="quality-control__title-container-badge">
-                              {%- render 'qc-badge-passed' -%}
-                              {% comment %} and here for the Not Passed{% endcomment %} 
-                            {% elsif quality_control_value =="Not Passed" %}
-                              {% render 'icon-not-passed-ellips' %}
-                              {{"sections.quality_control_tab.heading" | t }}
-                            </div>
-                            <div class="quality-control__title-container-badge">
-                            {% render 'qc-badge-not-passed' %}
-                          {% endif %}
-                            {% render 'icon-caret' %}
-                            </div>
-                        </div>
-                      </summary>
-                      <div class="quality-control__description">
-                        {% if quality_control_value == "Passed" %}
-                        {{ block.settings.content_passed}}
-                        {% elsif quality_control_value == "Not Passed" %}
-                        {{ block.settings.content_not_passed }}
-                        {% endif %}
-                      </div>
-                      <div class="quality-control__link">
-                        <a href="/pages/product-quality-control-item-condition-rating" target="_blank" rel="noopener noreferrer">{{"sections.quality_control_tab.link.text" | t }}</a> 
-                      </div>
-                    </details>
-                  </div>
-                  </div>
-                  </div>
-              {% endif %}
+            {% comment %} Remember to add != 'NEW/EXTENCT' when decided which tag will be used {% endcomment %}
+            {% comment %} if product.metafields.kameratori.quality_control.value != 'Error-QC' and product.metafields.kameratori.quality_control.value != blank {% endcomment %}
+            {%- for t in product.tags -%}
+                {% assign tag = t %}
+                  {% if tag contains 'QC-' and tag != 'QC-New' %}
+                    {%- assign quality_control_value = tag | remove_first: "QC-"-%}
+                        <div class={{quality_control_value | downcase|replace: " ", "-"}}>
+                        <div class="quality-control">
+                        <div class="accordion" {{ block.shopify_attributes }}>
+                            {%- if quality_control_value=="Passed" -%}
+                            <details>
+                            {%- elsif quality_control_value=="Not Passed" -%}
+                            <details open>
+                            {%- endif -%}  
+                            <summary>
+                                <div class="quality-control__title-container">
+                                  <div class="quality-control__title">
+                                    {% comment %} quality control value defines what we show next, first for Passed {% endcomment %}
+                                    {% if quality_control_value =="Passed" %}
+                                      {% render 'icon-passed-ellips' %}
+                                      {{"sections.quality_control_tab.heading" | t }}
+                                    </div>
+                                    <div class="quality-control__title-container-badge">
+                                      {%- render 'qc-badge-passed' -%}
+                                      {% comment %} and here for the Not Passed{% endcomment %} 
+                                    {% elsif quality_control_value =="Not Passed" %}
+                                      {% render 'icon-not-passed-ellips' %}
+                                      {{"sections.quality_control_tab.heading" | t }}
+                                    </div>
+                                    <div class="quality-control__title-container-badge">
+                                    {% render 'qc-badge-not-passed' %}
+                                  {% endif %}
+                                    {% render 'icon-caret' %}
+                                    </div>
+                                </div>
+                              </summary>
+                              <div class="quality-control__description">
+                                {% if quality_control_value == "Passed" %}
+                                {% comment %} content from the block-settings if want to use instead of metaobjects
+                                {{ block.settings.content_passed}}
+                                {% endcomment %}
+                                <p>{{ shop.metaobjects.quality_control.passed.description_medium }}</p>
+                                {% elsif quality_control_value == "Not Passed" %}
+                                {% comment %} content from the block-settings if want to use instead of metaobjects
+                                {{ block.settings.content_not_passed }}
+                                {% endcomment %}
+                                <p>{{ shop.metaobjects.quality_control.not-passed.description_medium}}</p>
+                                {% endif %}
+                              </div>
+                              <div class="quality-control__link">
+                                <a href="/pages/product-quality-control-item-condition-rating" target="_blank" rel="noopener noreferrer">{{"sections.quality_control_tab.link.text" | t }}</a> 
+                              </div>
+                            </details>
+                          </div>
+                          </div>
+                          </div>
+                {% endif %}
+              {% endfor %}
           {%- when 'quantity_selector' -%}
             <div class="product-form__input product-form__quantity" {{ block.shopify_attributes }}>
               <label class="form__label" for="Quantity-{{ section.id }}">

--- a/sections/qc-certified.liquid
+++ b/sections/qc-certified.liquid
@@ -1,17 +1,17 @@
 {{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
-<div class="qc__info">
-  <div class="qc__wrapper">
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
 {%- for block in section.blocks -%}
 {%- case block.type -%}
   {%- when 'qc_certified_badge' and -%}
     {%- if block.settings.certified -%}
-    <div class="qc__badge">
+    <div class="quality-control__badge">
       {%- render 'qc-badge-certified' -%}
     </div>
     {%- endif -%}
   {%- when 'qc_certified_description' -%}
-    <div class="qc__container--passed">
-      <div class="qc__text">
+    <div class="quality-control__container--passed">
+      <div class="quality-control__description">
         {{ block.settings.certified_text }}
       </div>
     </div>

--- a/sections/qc-not-passed.liquid
+++ b/sections/qc-not-passed.liquid
@@ -1,17 +1,17 @@
 {{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
-<div class="qc__info">
-  <div class="qc__wrapper">
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
 {%- for block in section.blocks -%}
 {%- case block.type -%}
   {%- when 'qc_not_passed_badge' and -%}
     {%- if block.settings.not_passed -%}
-    <div class="qc__badge">
+    <div class="quality-control__badge">
       {%- render 'qc-badge-not-passed' -%}
     </div>
     {%- endif -%}
   {%- when 'qc_not_passed_description' -%}
-    <div class="qc__container--not-passed">
-      <div class="qc__text">
+    <div class="quality-control__container--not-passed">
+      <div class="quality-control__description">
         {{ block.settings.not_passed_text }}
       </div>
     </div>

--- a/sections/qc-passed.liquid
+++ b/sections/qc-passed.liquid
@@ -1,17 +1,17 @@
 {{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
-<div class="qc__info">
-  <div class="qc__wrapper">
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
 {%- for block in section.blocks -%}
 {%- case block.type -%}
   {%- when 'qc_passed_badge' and -%}
     {%- if block.settings.passed -%}
-    <div class="qc__badge">
+    <div class="quality-control__badge">
       {%- render 'qc-badge-passed' -%}
     </div>
     {%- endif -%}
   {%- when 'qc_passed_description' -%}
-    <div class="qc__container--passed">
-      <div class="qc__text">
+    <div class="quality-control__container--passed">
+      <div class="quality-control__description">
         {{ block.settings.passed_text }}
       </div>
     </div>

--- a/sections/qc-reconditioned.liquid
+++ b/sections/qc-reconditioned.liquid
@@ -1,17 +1,17 @@
 {{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
-<div class="qc__info">
-  <div class="qc__wrapper">
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
 {%- for block in section.blocks -%}
 {%- case block.type -%}
   {%- when 'qc_reconditioned_badge' and -%}
     {%- if block.settings.reconditioned -%}
-    <div class="qc__badge">
+    <div class="quality-control__badge">
       {%- render 'qc-badge-reconditioned' -%}
     </div>
     {%- endif -%}
   {%- when 'qc_recon_description' -%}
-    <div class="qc__container--reconditioned">
-      <div class="qc__text">
+    <div class="quality-control__container--reconditioned">
+      <div class="quality-control__description">
         {{ block.settings.reconditioned_text }}
       </div>
     </div>


### PR DESCRIPTION
**Why are these changes introduced?**
These changes were introduced to make QC-section to be used in the theme editor. It can be added to different product pages before the proper launch of quality control. It uses qc-values passed and not passed at the moment and reads the values from the tags. The qc section on the pages use the same style files.

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
