### PR TITLE
Filter size display

### DIFF
--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -107,6 +107,7 @@
       "actual_item_image": "Actual item pictured",
       "stock_item_image": "Stock photo",
       "battery_info": " Compatible battery type(s) for the ",
+      "filter_info": "Filter thread size for ",
       "taxable_html": "Your countries <a class=\"link\" href=\"\/pages\/vat\">VAT<\/a>. incl. (EU only).",
       "not_taxable_html": "Price as shown. Used item, no deductible <a class=\"link\" href=\"\/pages\/vat\">VAT<\/a>.",
       "media": {

--- a/sections/main-product-description.liquid
+++ b/sections/main-product-description.liquid
@@ -70,19 +70,25 @@
             </div>
           {% endif %}
           {% endunless %}
-          {% comment %} Filter Size Added {% endcomment %}
+          {% comment %} Here starts the logic for showing products filter thread size {% endcomment %}
             {% for t in product.tags %}
             {% assign prefix = t | slice: 0, 12 %}
               {% if prefix == 'Filter-Size-' %}
                 {% assign filter_size = t | slice: 12, 25 | strip %}
                 <div>
-                  {{ "products.product.filter_info" | t }}{{product.title | remove_first: "-" }}
+                  {{ "products.product.filter_info" | t }}
+                  {{ product.title }}
+                  {%- assign category_collection = product.metafields.kameratori.category_collection.value -%}
+                  {%- if category_collection.title == "Lenses" -%}
+                  lens
+                  {% endif %}
                   is:
-                  <br>
-                  <b>{{filter_size}}</b>
-                </div>
-              {% endif %}
+                    <br>
+                    <b>{{ filter_size }}</b>
+                  </div>
+                {% endif %}
             {% endfor %}
+            {% comment %} And here it ends {% endcomment %}
           {% assign previous_content_section_shown = true %}
         {% endif %}
       {%- when 'main_kit_stock' -%}

--- a/sections/main-product-description.liquid
+++ b/sections/main-product-description.liquid
@@ -57,7 +57,8 @@
             <hr class="main-product-description shallow" />
           {% endif %}
           <b>{{ host_product.title }}</b>
-          <div>{{ host_product.description }}</div>
+          <div>{{ host_product.description }}
+          </div>
           {% unless host_product.description contains "Battery" or host_product.description contains "battery" %}
             {% if product.metafields.kameratori.batteries and product.metafields.kameratori.batteries.value.size > 0 %}
             <div>
@@ -69,6 +70,19 @@
             </div>
           {% endif %}
           {% endunless %}
+          {% comment %} Filter Size Added {% endcomment %}
+            {% for t in product.tags %}
+            {% assign prefix = t | slice: 0, 12 %}
+              {% if prefix == 'Filter-Size-' %}
+                {% assign filter_size = t | slice: 12, 25 | strip %}
+                <div>
+                  {{ "products.product.filter_info" | t }}{{product.title | remove_first: "-" }}
+                  is:
+                  <br>
+                  <b>{{filter_size}}</b>
+                </div>
+              {% endif %}
+            {% endfor %}
           {% assign previous_content_section_shown = true %}
         {% endif %}
       {%- when 'main_kit_stock' -%}

--- a/sections/main-product-description.liquid
+++ b/sections/main-product-description.liquid
@@ -57,8 +57,7 @@
             <hr class="main-product-description shallow" />
           {% endif %}
           <b>{{ host_product.title }}</b>
-          <div>{{ host_product.description }}
-          </div>
+          <div>{{ host_product.description }}</div>
           {% unless host_product.description contains "Battery" or host_product.description contains "battery" %}
             {% if product.metafields.kameratori.batteries and product.metafields.kameratori.batteries.value.size > 0 %}
             <div>


### PR DESCRIPTION
**Why are these changes introduced?**
To show products filter thread size on the website, if product has one. Makes customers life easier. Uses items tags and category collection metafield (to check if category collection is lenses). Added proper locales file for default language,

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
