### PR TITLE
Add qc-sections for quality rating page

### DIFF
--- a/sections/qc-certified.liquid
+++ b/sections/qc-certified.liquid
@@ -1,0 +1,67 @@
+{{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
+{%- for block in section.blocks -%}
+{%- case block.type -%}
+  {%- when 'qc_certified_badge' and -%}
+    {%- if block.settings.certified -%}
+    <div class="quality-control__badge">
+      {%- render 'qc-badge', value: "Certified" -%}
+    </div>
+    {%- endif -%}
+  {%- when 'qc_certified_description' -%}
+    <div class="quality-control__container--passed">
+      <div class="quality-control__description">
+        {{ block.settings.certified_text }}
+      </div>
+    </div>
+{%- endcase -%}
+{%- endfor -%}
+  </div>
+</div>
+
+
+{% schema %}
+{
+  "name": "QC Certified Section",
+  "presets": [
+    {
+      "name": "QC Certified Section",
+      "category": "ADVANCED LAYOUT",
+    "blocks": [
+        {
+          "type": "qc_certified_badge"
+        },
+        {
+          "type": "qc_certified_description"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "qc_certified_badge",
+      "name": "QC-Certified Badge",
+      "settings": [{
+          "type": "checkbox",
+          "id": "certified",
+          "label": "t:sections.qc_certified.blocks.qc_certified_badge.settings.certified.label",
+          "default": true
+        }
+      ]
+    },
+    {
+      "type": "qc_certified_description",
+      "name": "QC Certified Description",
+      "settings": [
+        {
+          "type": "richtext",
+          "id": "certified_text",
+          "default": "<p> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>",
+          "label": "t:sections.qc_certified.blocks.qc_certified_description.settings.certified_text.label"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/qc-not-passed.liquid
+++ b/sections/qc-not-passed.liquid
@@ -1,0 +1,65 @@
+{{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
+{%- for block in section.blocks -%}
+{%- case block.type -%}
+  {%- when 'qc_not_passed_badge' and -%}
+    {%- if block.settings.not_passed -%}
+    <div class="quality-control__badge">
+      {%- render 'qc-badge', value: "Not Passed" -%}
+    </div>
+    {%- endif -%}
+  {%- when 'qc_not_passed_description' -%}
+    <div class="quality-control__container--not-passed">
+      <div class="quality-control__description">
+        {{ block.settings.not_passed_text }}
+      </div>
+    </div>
+{%- endcase -%}
+{%- endfor -%}
+  </div>
+</div>
+{% schema %}
+{
+  "name": "QC Not Passed Section",
+  "presets": [
+    {
+      "name": "QC Not Passed Section",
+      "category": "ADVANCED LAYOUT",
+    "blocks": [
+        {
+          "type": "qc_not_passed_badge"
+        },
+        {
+          "type": "qc_not_passed_description"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "qc_not_passed_badge",
+      "name": "QC-Not Passed Badge",
+      "settings": [{
+          "type": "checkbox",
+          "id": "not_passed",
+          "label": "t:sections.qc_not_passed.blocks.qc_not_passed_badge.settings.not_passed.label",
+          "default": true
+        }
+      ]
+    },
+    {
+      "type": "qc_not_passed_description",
+      "name": "QC Not Passed Description",
+      "settings": [
+        {
+          "type": "richtext",
+          "id": "not_passed_text",
+          "default": "<p>Untested or: tested, inspected, and found to have significant flaws that affect or prevent normal use. These items should be considered broken. Repair may or may not be possible.</p>",
+          "label": "t:sections.qc_not_passed.blocks.qc_not_passed_description.settings.not_passed_text.label"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/sections/qc-passed.liquid
+++ b/sections/qc-passed.liquid
@@ -1,0 +1,65 @@
+{{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
+{%- for block in section.blocks -%}
+{%- case block.type -%}
+  {%- when 'qc_passed_badge' and -%}
+    {%- if block.settings.passed -%}
+    <div class="quality-control__badge">
+        {%- render 'qc-badge', value: "Passed" -%}
+    </div>
+    {%- endif -%}
+  {%- when 'qc_passed_description' -%}
+    <div class="quality-control__container--passed">
+      <div class="quality-control__description">
+        {{ block.settings.passed_text }}
+      </div>
+    </div>
+{%- endcase -%}
+{%- endfor -%}
+  </div>
+</div>
+{% schema %}
+{
+  "name": "QC Passed Section",
+  "presets": [
+    {
+      "name": "QC Passed Section",
+      "category": "ADVANCED LAYOUT",
+    "blocks": [
+        {
+          "type": "qc_passed_badge"
+        },
+        {
+          "type": "qc_passed_description"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "qc_passed_badge",
+      "name": "QC-Passed Badge",
+      "settings": [{
+          "type": "checkbox",
+          "id": "passed",
+          "label": "t:sections.qc_passed.blocks.qc_passed_badge.settings.passed.label",
+          "default": true
+        }
+      ]
+    },
+    {
+      "type": "qc_passed_description",
+      "name": "QC Passed Description",
+      "settings": [
+        {
+          "type": "richtext",
+          "id": "passed_text",
+          "default": "<p> Tested, inspected, cleaned and working with no significant flaws. These items can be considered “ready to use” for their intended purpose. Minor flaws are possible and are noted in the product description. </p>",
+          "label": "t:sections.qc_passed.blocks.qc_passed_description.settings.passed_text.label"
+         }
+        ]
+      }
+    ]
+  }
+{% endschema %}

--- a/sections/qc-reconditioned.liquid
+++ b/sections/qc-reconditioned.liquid
@@ -1,0 +1,65 @@
+{{ 'section-quality-control.css' | asset_url | stylesheet_tag }}
+<div class="quality-control__info">
+  <div class="quality-control__wrapper">
+{%- for block in section.blocks -%}
+{%- case block.type -%}
+  {%- when 'qc_reconditioned_badge' and -%}
+    {%- if block.settings.reconditioned -%}
+    <div class="quality-control__badge">
+      {%- render 'qc-badge', value: "Reconditioned" -%}
+    </div>
+    {%- endif -%}
+  {%- when 'qc_recon_description' -%}
+    <div class="quality-control__container--reconditioned">
+      <div class="quality-control__description">
+        {{ block.settings.reconditioned_text }}
+      </div>
+    </div>
+{%- endcase -%}
+{%- endfor -%}
+  </div>
+</div>
+{% schema %}
+{
+  "name": "QC Reconditioned Section",
+  "presets": [
+  {
+    "name": "QC Reconditioned Section",
+    "category": "ADVANCED LAYOUT",
+  "blocks": [
+      {
+        "type": "qc_reconditioned_badge"
+      },
+      {
+        "type": "qc_recon_description"
+      }
+    ]
+  }
+],
+  "blocks": [
+    {
+      "type": "qc_reconditioned_badge",
+      "name": "QC-Reconditioned Badge",
+      "settings": [{
+          "type": "checkbox",
+          "id": "reconditioned",
+          "label": "t:sections.qc_reconditioned.blocks.qc_reconditioned_badge.settings.reconditioned.label",
+          "default": true
+        }
+      ]
+    },
+    {
+      "type": "qc_recon_description",
+      "name": "QC Reconditioned Descr.",
+      "settings": [
+        {
+          "type": "richtext",
+          "id": "reconditioned_text",
+          "default": "<p>  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. </p>",
+          "label": "t:sections.qc_reconditioned.blocks.qc_reconditioned_description.settings.reconditioned_text.label"
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
**Why are these changes introduced?**
Add qc-sections to be used on different pages, mostly for the quality rating page

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
