### PR TITLE
Change qc-badge svg size & adjust styling

### DIFF
--- a/assets/section-qc-cards.css
+++ b/assets/section-qc-cards.css
@@ -27,6 +27,15 @@
     max-width: 500px;
 }
 
+.qc-card-badge {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    align-items: center;
+}
+
 .qc-img {
     display: flex;
     object-fit: cover;

--- a/assets/section-qc-new.css
+++ b/assets/section-qc-new.css
@@ -32,7 +32,7 @@
     color: #202223;
     font-style: normal;
     font-weight: 600;
-    font-size: 15px;
+    font-size: 1.8rem;
     line-height: 20px;
     
 
@@ -43,11 +43,6 @@
     margin-top: 18px;
     width: auto;
     height: auto;
-    font: normal 400 1.4rem/1.6rem;
-    font-style: normal;
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 20px;
     color: #686868;
     flex: none;
     order: 0;
@@ -75,8 +70,8 @@
 }
 
 .qc-new-badge {
-    width: 24px;
-    height: 24px;
+    width: 28px;
+    height: 28px;
     display: flex;
     flex-direction: row;
     justify-content: space-around;
@@ -128,6 +123,7 @@
  .qc-collection-new > a {
     color: #458FFF;
     text-decoration: none;
+    font-size: 1.6rem;
  }
 
  .qc-collection-new > a:hover {

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -211,7 +211,7 @@
     },
     "quality_control_value_box": {
       "link": {
-        "text": "See our other ratings"
+        "text": "See our other 3 condition labels"
       },
       "info": {
         "text": "This item & "

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -269,9 +269,9 @@
                                               {% elsif quality_control_value == "Certified" %}
                                                 {% assign qc = shop.metaobjects.quality_control.certified %}
                                               {% endif %}
+                                              </div>
                                               <div class="qc-collection-new">({{ "sections.quality_control_value_box.info.text" | t }} 
                                                 <a href={{ qc.collection.value.url }} > {{ qc.collection.value.all_products_count }}</a> {{ "sections.quality_control_value_box.info_2.text" | t }})
-                                              </div>
                                               </div>
                                               <div class="quality-control-new__title-container-badge">
                                                 {%- render 'icon-caret' -%}

--- a/sections/qc-cards.liquid
+++ b/sections/qc-cards.liquid
@@ -13,7 +13,9 @@
       </div>
       <div class="qc-card--heading">
         <div class="qc-badge-title h3">
-          {%- render 'qc-badge-small-color', value: qc_values.title -%}
+          <div class="qc-card-badge">
+            {%- render 'qc-badge-small-color', value: qc_values.title -%}
+          </div>
           {{ qc_values.title }}
         </div>
         <div class="qc-items-text">
@@ -43,7 +45,9 @@
         </div>
         <div class="qc-card--heading">
           <div class="qc-badge-title h3">
-          {%- render 'qc-badge-small-color', value: qc_values.title -%}
+            <div class="qc-card-badge">
+              {%- render 'qc-badge-small-color', value: qc_values.title -%}
+            </div>
           {{ qc_values.title }}
           </div>
           <div class="qc-items-text">
@@ -75,7 +79,9 @@
         </div>
         <div class="qc-card--heading">
           <div class="qc-badge-title h3">
+            <div class="qc-card-badge">
               {%- render 'qc-badge-small-color', value: qc_values.title -%}
+            </div>
           {{ qc_values.title }}
           </div>
           <div class="qc-items-text">
@@ -105,7 +111,9 @@
     </div>
       <div class="qc-card--heading">
         <div class="qc-badge-title h3">
-          {%- render 'qc-badge-small-color', value: qc_values.title -%}  
+          <div class="qc-card-badge">
+            {%- render 'qc-badge-small-color', value: qc_values.title -%}
+          </div>  
           {{ qc_values.title }}
         </div>
         <div class="qc-items-text">

--- a/snippets/qc-badge-small-color.liquid
+++ b/snippets/qc-badge-small-color.liquid
@@ -1,10 +1,10 @@
 {%- if value == 'Passed' -%}
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="100%" height="100%" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M4.88886 11.9778L8.57597 15.5174C8.78514 15.7182 9.12072 15.6996 9.30635 15.4768L17.1111 6.11111" stroke="#214E9D" stroke-width="2" stroke-linecap="round"/>
     </svg>
     
 {% elsif value == 'Not Passed' %}
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="100%" height="100%" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M7.33325 6.11111L10.9999 6.11111" stroke="#F88545" stroke-width="2" stroke-linecap="round"/>
         <path d="M7.33325 14.6667L9.7777 14.6667" stroke="#F88545" stroke-width="2" stroke-linecap="round"/>
         <path d="M7.33325 9.77777L14.6666 9.77777" stroke="#F88545" stroke-width="2" stroke-linecap="round"/>
@@ -13,11 +13,11 @@
         <path d="M19.5556 20.7778L17.9514 19.1736" stroke="#F88545" stroke-width="2" stroke-linecap="round"/>
     </svg> 
 {% elsif value == 'Certified' %}
-    <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="100%" height="100%" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M11 22C17.0751 22 22 17.0751 22 11C22 4.92487 17.0751 0 11 0C4.92487 0 0 4.92487 0 11C0 17.0751 4.92487 22 11 22ZM16.1896 7.95803C16.5347 7.52677 16.4647 6.89747 16.0335 6.55246C15.6022 6.20746 14.9729 6.27738 14.6279 6.70864L9.73855 12.8203L7.73493 10.8167C7.3444 10.4262 6.71124 10.4262 6.32071 10.8167C5.93019 11.2072 5.93019 11.8404 6.32072 12.2309L8.71935 14.6296C9.35152 15.2617 10.3928 15.204 10.9513 14.5059L16.1896 7.95803Z" fill="#214E9D"/>
     </svg>
 {% elsif value == 'Restored' %}
-    <svg width="20" height="22" viewBox="0 0 20 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="91%" height="100%" viewBox="0 0 20 22" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" clip-rule="evenodd" d="M18.324 3.34677L11.2798 0.327825C10.2599 -0.109275 9.10538 -0.109275 8.08548 0.327825L1.04128 3.34677C0.54436 3.55973 0.222168 4.04835 0.222168 4.58899V11.6882C0.222168 14.307 1.48689 16.7646 3.61789 18.2868L8.11154 21.4965C9.05136 22.1678 10.3139 22.1678 11.2537 21.4965L15.7474 18.2868C17.8784 16.7646 19.1431 14.307 19.1431 11.6882V4.58899C19.1431 4.04835 18.8209 3.55974 18.324 3.34677ZM14.5178 8.37732C14.8629 7.94606 14.7929 7.31677 14.3617 6.97176C13.9304 6.62675 13.3011 6.69667 12.9561 7.12793L8.24809 13.013L6.33513 11.1C5.9446 10.7095 5.31144 10.7095 4.92091 11.1C4.53039 11.4905 4.53039 12.1237 4.92091 12.5142L7.22889 14.8222C7.86105 15.4544 8.90236 15.3967 9.46085 14.6986L14.5178 8.37732Z" fill="#0D9488"/>
     </svg>
     


### PR DESCRIPTION
**Why are these changes introduced?**
Needed to have bigger sized qc-badge-icons so changed the svg:s and altered stylefiles. Changed also one string in language files.

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
