### PR TITLE
Add checkbox show price for featured collections

### DIFF
--- a/locales/en.default.schema.json
+++ b/locales/en.default.schema.json
@@ -643,7 +643,9 @@
         "show_rating": {
           "label": "Show product rating",
           "info": "To display a rating, add a product rating app. [Learn more](https:\/\/help.shopify.com\/manual\/online-store\/themes\/os20\/themes-by-shopify\/dawn\/sections#featured-collection-show-product-rating)"
-        }
+        },
+        "show_price": {
+          "label": "Show product price"}
       },
       "presets": {
         "name": "Featured collection"

--- a/sections/featured-collection.liquid
+++ b/sections/featured-collection.liquid
@@ -38,7 +38,7 @@
             show_vendor: section.settings.show_vendor,
             show_image_outline: section.settings.show_image_outline,
             show_rating: section.settings.show_rating,
-            show_price: true
+            show_price: section.settings.show_price
           %}
         </li>
       {%- else -%}
@@ -168,6 +168,12 @@
       "default": false,
       "label": "t:sections.featured-collection.settings.show_rating.label",
       "info": "t:sections.featured-collection.settings.show_rating.info"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_price",
+      "default": true,
+      "label": "t:sections.featured-collection.settings.show_price.label"
     }
   ],
   "presets": [


### PR DESCRIPTION
**Why are these changes introduced?**
Added checkbox for featured collections to show price/not to show price. Default is true so price is shown.

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
